### PR TITLE
POM files updated, minor issues with StardogReadQuery resolved

### DIFF
--- a/nifi-stardog-nar/pom.xml
+++ b/nifi-stardog-nar/pom.xml
@@ -36,6 +36,12 @@
             <artifactId>nifi-stardog-processors</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
+        <dependency>
+            <groupId>com.complexible.stardog</groupId>
+            <artifactId>client-http</artifactId>
+            <version>${stardog.version}</version>
+            <type>pom</type>
+        </dependency>
     </dependencies>
 
 </project>

--- a/nifi-stardog-processors/pom.xml
+++ b/nifi-stardog-processors/pom.xml
@@ -39,17 +39,6 @@
         </plugins>
     </build>
 
-    <properties>
-        <stardog.version>7.1.2</stardog.version>
-    </properties>
-
-    <repositories>
-        <repository>
-            <id>stardog-public</id>
-            <url>https://maven.stardog.com</url>
-        </repository>
-    </repositories>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.nifi</groupId>

--- a/nifi-stardog-processors/src/main/java/com/stardog/nifi/StardogReadQuery.java
+++ b/nifi-stardog-processors/src/main/java/com/stardog/nifi/StardogReadQuery.java
@@ -175,6 +175,8 @@ public class StardogReadQuery extends AbstractStardogProcessor {
 					.add(QUERY)
 					.add(QUERY_TIMEOUT)
 					.add(OUTPUT_FORMAT)
+					.add(REASONING)
+					.add(REASONING_SCHEMA)
 					.build();
 
 	@Override
@@ -199,7 +201,7 @@ public class StardogReadQuery extends AbstractStardogProcessor {
 		String queryStr = validationContext.getProperty(QUERY).getValue();
 		QueryType queryType = SPARQLUtil.getType(queryStr);
 
-		if (queryType != QueryType.SELECT || queryType != QueryType.GRAPH) {
+		if (queryType != QueryType.SELECT && queryType != QueryType.GRAPH) {
 			String msg = String.format("Unsupported query type: %s", queryType);
 			results.add(new ValidationResult.Builder().valid(false).explanation(msg).build());
 		}

--- a/pom.xml
+++ b/pom.xml
@@ -27,9 +27,20 @@
     <version>1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
+    <properties>
+        <stardog.version>7.2.1</stardog.version>
+    </properties>
+
     <modules>
         <module>nifi-stardog-processors</module>
         <module>nifi-stardog-nar</module>
     </modules>
+
+     <repositories>
+        <repository>
+            <id>stardog-public</id>
+            <url>https://maven.stardog.com</url>
+        </repository>
+    </repositories>
 
 </project>


### PR DESCRIPTION
Updates to `StardogReadQuery`:
- the logical operator in `customValidate` changed to `&&`
- `REASONING`and `RESONING_SCHEMA`added to `PROPERTIES` to prevent the NPE:
 
```
WARN [Timer-Driven Process Thread-2] o.a.n.controller.tasks.ConnectableTask Administratively Yielding StardogReadQuery[id=cc0831f2-d9f8-1a5a-fcc4-e7
14cd6cd5c1] due to uncaught Exception: java.lang.NullPointerException
java.lang.NullPointerException: null
        at com.stardog.nifi.StardogReadQuery.onTrigger(StardogReadQuery.java:239)
```