### PR TITLE
StardogPut support for selective clearing of target graph

### DIFF
--- a/nifi-stardog-connection-service-api-nar/pom.xml
+++ b/nifi-stardog-connection-service-api-nar/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>com.stardog</groupId>
 		<artifactId>nifi-stardog-bundle</artifactId>
-		<version>2.0.0</version>
+		<version>${revision}</version>
 	</parent>
 
 	<artifactId>nifi-stardog-connection-service-api-nar</artifactId>

--- a/nifi-stardog-connection-service-api/pom.xml
+++ b/nifi-stardog-connection-service-api/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>com.stardog</groupId>
 		<artifactId>nifi-stardog-bundle</artifactId>
-		<version>2.0.0</version>
+		<version>${revision}</version>
 	</parent>
 
 	<artifactId>nifi-stardog-connection-service-api</artifactId>

--- a/nifi-stardog-nar/pom.xml
+++ b/nifi-stardog-nar/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.stardog</groupId>
         <artifactId>nifi-stardog-bundle</artifactId>
-        <version>2.0.0</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>nifi-stardog-nar</artifactId>

--- a/nifi-stardog-processors/pom.xml
+++ b/nifi-stardog-processors/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>com.stardog</groupId>
 		<artifactId>nifi-stardog-bundle</artifactId>
-		<version>2.0.0</version>
+		<version>${revision}</version>
 	</parent>
 
 	<artifactId>nifi-stardog-processors</artifactId>

--- a/nifi-stardog-processors/src/main/java/com/stardog/nifi/StardogPut.java
+++ b/nifi-stardog-processors/src/main/java/com/stardog/nifi/StardogPut.java
@@ -364,7 +364,7 @@ public class StardogPut extends AbstractStardogProcessor {
                 String mappingString = mappingsPath.isSet()
                                        ? Files2.toString(new File(mappingsPath.getValue()).toPath(), Charsets.UTF_8)
                                        : null;
-
+                // Optionally clear target graph
                 if (clearTargetGraph) {
                     connection.begin();
                     try {
@@ -376,7 +376,8 @@ public class StardogPut extends AbstractStardogProcessor {
                         throw t;
                     }
                 }
-                else if (queryStr != null) {
+                // Insert data or selectively clear graph(s)
+                if (queryStr != null) {
                     UpdateQuery updateQuery = connection.update(queryStr);
                     updateQuery.execute();
                     logger.info("Update query successfully executed");
@@ -410,15 +411,15 @@ public class StardogPut extends AbstractStardogProcessor {
                 vgConn.importFile(mappingString, properties, connection.name(), targetGraph, in, fileType);
             }
             else {
-                if (!clearTargetGraph && queryStr != null) {
-                    UpdateQuery updateQuery = connection.update(queryStr);
-                    updateQuery.execute();
-                    logger.info("Update query successfully executed");
-                }
                 connection.begin();
                 try {
                     if (clearTargetGraph) {
                         connection.remove().context(targetGraph);
+                    }
+                    if (queryStr != null) {
+                        UpdateQuery updateQuery = connection.update(queryStr);
+                        updateQuery.execute();
+                        logger.info("Update query successfully executed");
                     }
                     IO io = connection.add()
                                       .io()

--- a/nifi-stardog-processors/src/test/java/com/stardog/nifi/StardogUpdateQueryTest.java
+++ b/nifi-stardog-processors/src/test/java/com/stardog/nifi/StardogUpdateQueryTest.java
@@ -36,7 +36,7 @@ public class StardogUpdateQueryTest extends AbstractStardogQueryTest {
 
 	@Override
 	protected String getValidQuery() {
-		return "INSERT DATA { :I :am :U }";
+		return "PREFIX : <http://api.stardog.com/> INSERT DATA { :I :am :U }";
 	}
 
 	@Test

--- a/nifi-stardog-services-nar/pom.xml
+++ b/nifi-stardog-services-nar/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.stardog</groupId>
         <artifactId>nifi-stardog-bundle</artifactId>
-        <version>2.0.0</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>nifi-stardog-services-nar</artifactId>

--- a/nifi-stardog-services/pom.xml
+++ b/nifi-stardog-services/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>com.stardog</groupId>
 		<artifactId>nifi-stardog-bundle</artifactId>
-		<version>2.0.0</version>
+		<version>${revision}</version>
 	</parent>
 
 	<artifactId>nifi-stardog-services</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -10,12 +10,14 @@
 
     <groupId>com.stardog</groupId>
     <artifactId>nifi-stardog-bundle</artifactId>
-    <version>2.0.0</version>
+    <version>${revision}</version>
     <packaging>pom</packaging>
 
     <properties>
         <nifi.version>1.21.0</nifi.version>
-        <stardog.version>10.0.0</stardog.version>
+        <stardog.version>10.0.0</stardog.version>        
+        <nifi.groovy.version>2.5.6</nifi.groovy.version><!-- https://stackoverflow.com/a/69388478 -->
+        <revision>2.0.1</revision><!-- clear graph query added in 2.0.1 -->
     </properties>
 
     <modules>
@@ -54,6 +56,7 @@
         <repository>
             <id>stardog-public</id>
             <url>https://maven.stardog.com</url>
-        </repository>
+        </repository>        
     </repositories>
+
 </project>


### PR DESCRIPTION
- The QUERY option was added to supply a SPARQL update and selectively clear the target graph (instead of dropping it completely). 
- The StardogPutTest class was accordingly extended 
- The nifi-stardog-bundle  (parent) and the module POMs were updated to resolve missing dependency issue (org.codehaus.groovy:groovy-eclipse-batch:jar:2.5.4-01) and inherit parent version via Maven ${revision} variable
