### PR TITLE
fix runner setEnvironmentVariableValue on testClearQuery

### DIFF
--- a/nifi-stardog-processors/src/test/java/com/stardog/nifi/StardogPutTest.java
+++ b/nifi-stardog-processors/src/test/java/com/stardog/nifi/StardogPutTest.java
@@ -104,7 +104,7 @@ public class StardogPutTest extends AbstractStardogProcessorTest {
 		}
 		// Assign a SPARQL update to selectively clear the graph before the ingestion
 		TestRunner runner = newTestRunner();
-		runner.setVariable(DATABASE_VAR_NAME, getStardogDatabase());
+		runner.setEnvironmentVariableValue(DATABASE_VAR_NAME, getStardogDatabase());
 		runner.enqueue("{ \"val\" : \"1\" }");
 		runServerExpressionTest(runner, "prefix : <"+ NS +"> with <tag:g1> delete { ?s a :OldType } where { ?s a :OldType }");
 	}


### PR DESCRIPTION
fix runner setEnvironmentVariableValue on testClearQuery as it was using setProperty but failing on test:
error: cannot find symbol
[ERROR]   symbol:   method setVariable(String,String)
[ERROR]   location: variable runner of type TestRunner